### PR TITLE
[Mod/#68] 1차 QA - 홈, 온보딩, 로그인, 회원가입 디테일 수정

### DIFF
--- a/app/src/main/java/com/paw/key/core/designsystem/component/PawkeyButton.kt
+++ b/app/src/main/java/com/paw/key/core/designsystem/component/PawkeyButton.kt
@@ -26,30 +26,29 @@ private fun PreviewPawkeyButton() {
         Column (
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ){
-            // 초록색 버튼
+            // 기본 초록색 버튼 (활성화)
             PawkeyButton(
                 text = "신규 계정으로 회원가입",
                 enabled = true,
                 onClick = {}
             )
 
-            // 회색 버튼
+            // 기본 회색 버튼 (비활성화)
             PawkeyButton(
                 text = "신규 계정으로 회원가입",
                 enabled = false,
                 onClick = {}
             )
 
-            // 활성화 - 빈 상자
+            // 활성화 - 흰 배경, 초록 테두리
             PawkeyButton(
                 text = "신규 계정으로 회원가입",
                 enabled = true,
                 onClick = {},
-                isBorder = false,
                 isBackGround = true
             )
 
-            // 비활성화 - 빈 상자
+            // 비활성화 - 흰 배경, 회색 테두리
             PawkeyButton(
                 text = "신규 계정으로 회원가입",
                 enabled = false,
@@ -57,13 +56,30 @@ private fun PreviewPawkeyButton() {
                 isBackGround = true
             )
 
-            // 투명 border
+            // 활성화 - 흰 배경, 테두리 없음
             PawkeyButton(
                 text = "신규 계정으로 회원가입",
                 enabled = true,
                 onClick = {},
-                isBorder = true,
-                isBackGround = true
+                isBackGround = true,
+                isBorder = false
+            )
+
+            // 비활성화 - 흰 배경, 테두리 없음
+            PawkeyButton(
+                text = "신규 계정으로 회원가입",
+                enabled = false,
+                onClick = {},
+                isBackGround = true,
+                isBorder = false
+            )
+
+            // 초록색 버튼 - 테두리 없음
+            PawkeyButton(
+                text = "신규 계정으로 회원가입",
+                enabled = true,
+                onClick = {},
+                isBorder = false
             )
         }
     }
@@ -76,25 +92,33 @@ fun PawkeyButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     isBackGround: Boolean = false,
-    isBorder: Boolean = false
+    isBorder: Boolean = true
 ) {
+
+    val actualEnabled = if (!isBackGround) {
+        enabled
+    } else {
+        enabled
+    }
+
     val backgroundColor = when {
-        enabled && !isBackGround -> PawKeyTheme.colors.green500
-        enabled && isBackGround -> PawKeyTheme.colors.white1
-        !enabled && isBackGround -> PawKeyTheme.colors.white1
+        actualEnabled && !isBackGround -> PawKeyTheme.colors.green500
+        actualEnabled && isBackGround -> PawKeyTheme.colors.white1
+        !actualEnabled && isBackGround -> PawKeyTheme.colors.white1
         else -> PawKeyTheme.colors.gray200
     }
 
     val contentColor = when {
-        enabled && !isBackGround -> PawKeyTheme.colors.white1
-        enabled && isBackGround -> PawKeyTheme.colors.green500
-        !enabled && isBackGround -> PawKeyTheme.colors.gray100
+        actualEnabled && !isBackGround -> PawKeyTheme.colors.white1
+        actualEnabled && isBackGround -> PawKeyTheme.colors.green500
+        !actualEnabled && isBackGround -> PawKeyTheme.colors.gray100
         else -> PawKeyTheme.colors.white1
     }
 
     val borderColor = when {
-        enabled && isBackGround -> PawKeyTheme.colors.green500
-        !enabled && isBackGround -> PawKeyTheme.colors.gray200
+        !isBorder -> Color.Transparent
+        actualEnabled && isBackGround -> PawKeyTheme.colors.green500
+        !actualEnabled && isBackGround -> PawKeyTheme.colors.gray200
         else -> Color.Transparent
     }
 
@@ -102,8 +126,14 @@ fun PawkeyButton(
         modifier = modifier
             .fillMaxWidth()
             .background(backgroundColor, shape = RoundedCornerShape(8.dp))
-            .then(if (isBorder || isBackGround) Modifier.border(1.dp, borderColor, RoundedCornerShape(8.dp)) else Modifier)
-            .noRippleClickable{ onClick() }
+            .border(
+                width = 1.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .noRippleClickable {
+                if (actualEnabled) onClick()
+            }
             .padding(vertical = 14.dp),
         contentAlignment = Alignment.Center
     ) {
@@ -114,4 +144,3 @@ fun PawkeyButton(
         )
     }
 }
-

--- a/app/src/main/java/com/paw/key/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/home/HomeScreen.kt
@@ -161,10 +161,8 @@ fun HomeScreen(
                     date = "년도/월/일",
                     onCLickItem = {}
                 )
+                Spacer(modifier = Modifier.height(48.dp))
             }
-            item{}
-            item{}
-
 
         }
 

--- a/app/src/main/java/com/paw/key/presentation/ui/home/component/DaytimeCard.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/home/component/DaytimeCard.kt
@@ -72,7 +72,7 @@ fun DaytimeCard(
             )
         }
         Icon(
-            imageVector = ImageVector.vectorResource(R.drawable.img_home_sunset),
+            imageVector = ImageVector.vectorResource(R.drawable.img_home_sunrise),
             contentDescription = "daytime",
             tint = Color.Unspecified,
         )

--- a/app/src/main/java/com/paw/key/presentation/ui/home/component/RowCalendar.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/home/component/RowCalendar.kt
@@ -69,7 +69,9 @@ fun RowCalendar(
             Text(
                 text = date,
                 color = PawKeyTheme.colors.black,
-                style = PawKeyTheme.typography.head18Sb
+                style = PawKeyTheme.typography.head18Sb,
+                modifier = Modifier
+                    .padding(bottom = 28.dp)
             )
 
             LazyRow(
@@ -82,13 +84,16 @@ fun RowCalendar(
                     val dates = listOf("14", "15", "16", "17", "18", "19", "20")
                     val days = listOf("월", "화", "수", "목", "금", "토", "일")
                     val hasActivity = listOf(true, true, false, true, false, false, false)
+                    val selectedIndex = 3
+                    val todayIndex = 6
 
                     CalendarItem(
                         date = dates[index],
                         day = days[index],
                         state = hasActivity[index],
-                        isSelected = index == 3, // 17일이 선택됨
-                        isToday = index == 6 // 20일이 오늘
+                        isSelected = index == selectedIndex,
+                        isToday = index == todayIndex,
+                        isAfterSelected = index > selectedIndex && index < todayIndex
                     )
                 }
             }
@@ -104,6 +109,7 @@ private fun CalendarItem(
     state: Boolean = false,
     isSelected: Boolean = false,
     isToday: Boolean = false,
+    isAfterSelected: Boolean = false,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -133,6 +139,7 @@ private fun CalendarItem(
                     color = when {
                         isSelected -> PawKeyTheme.colors.white1
                         isToday -> Color.Red
+                        isAfterSelected -> PawKeyTheme.colors.black
                         else -> PawKeyTheme.colors.gray900.copy(alpha = 0.6f)
                     },
                     style = PawKeyTheme.typography.body14R,
@@ -143,6 +150,7 @@ private fun CalendarItem(
                     color = when {
                         isSelected -> PawKeyTheme.colors.white1
                         isToday -> Color.Red
+                        isAfterSelected -> PawKeyTheme.colors.black
                         else -> PawKeyTheme.colors.gray900.copy(alpha = 0.6f)
                     },
                     style = PawKeyTheme.typography.body14R,

--- a/app/src/main/java/com/paw/key/presentation/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/login/LoginScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -77,7 +78,7 @@ fun LoginScreen(
         modifier = modifier
             .fillMaxSize()
             .background(PawKeyTheme.colors.white1)
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = 16.dp, vertical = 60.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -122,7 +123,7 @@ fun LoginScreen(
             suffix = {
                 Icon(
                     imageVector = ImageVector.vectorResource(
-                        if (!isPasswordVisible) R.drawable.ic_eye_linear_valid else R.drawable.ic_eye_linear_invalid
+                        if (!isPasswordVisible) R.drawable.ic_eye_linear_gray_valid else R.drawable.ic_eye_linear_invalid
                     ),
                     contentDescription = null,
                     modifier = Modifier.noRippleClickable(onClickIcon),
@@ -153,7 +154,25 @@ fun LoginScreen(
                 .fillMaxWidth()
                 .navigationBarsPadding()
         )
+    }
+}
 
-        Spacer(modifier = Modifier.height(60.dp))
+@Preview(showBackground = true)
+@Composable
+private fun PreviewLoginScreen(){
+    PawKeyTheme{
+        LoginScreen(
+            paddingValues = PaddingValues(),
+            navigateUp = {},
+            navigateNext = {},
+            onEmailChanged = {},
+            onPasswordChanged = {},
+            onClickIcon = {},
+            snackBarHostState = SnackbarHostState(),
+            email = "",
+            password = "",
+            isPasswordVisible = false,
+            isLoginFormValid = true,
+        )
     }
 }

--- a/app/src/main/java/com/paw/key/presentation/ui/onboard/OnboardingScreen.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/onboard/OnboardingScreen.kt
@@ -12,6 +12,10 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.paw.key.core.designsystem.component.PawkeyButton
@@ -70,12 +74,17 @@ fun OnboardingScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 16.dp, vertical = 48.dp)
+                .padding(horizontal = 16.dp, vertical = 60.dp)
         ) {
-            Spacer(modifier = Modifier.height(36.dp))
 
             Text(
-                text = "안녕하세요\n우리 강아지를 위한 산책,\n${"PAWKEY"}와 함께해요! ",
+                text = buildAnnotatedString {
+                    append("안녕하세요\n우리 강아지를 위한 산책,\n")
+                    withStyle(style = SpanStyle(color = PawKeyTheme.colors.green500)) {
+                        append("PAWKEY")
+                    }
+                    append("와 함께해요! ")
+                },
                 color = PawKeyTheme.colors.black,
                 style = PawKeyTheme.typography.head22B
             )
@@ -95,6 +104,7 @@ fun OnboardingScreen(
                     text = "기존 계정으로 로그인",
                     enabled = true,
                     isBackGround = true,
+                    isBorder = false,
                     onClick = { navigateSignUp() },
                 )
             }

--- a/app/src/main/java/com/paw/key/presentation/ui/signup/SignUpDogScreen.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/signup/SignUpDogScreen.kt
@@ -1,5 +1,15 @@
 package com.paw.key.presentation.ui.signup
 
+import android.Manifest
+import android.net.Uri
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -16,6 +26,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -24,12 +35,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import coil.compose.AsyncImage
 import com.paw.key.R
 import com.paw.key.core.designsystem.component.PawkeyButton
 import com.paw.key.core.designsystem.theme.PawKeyTheme
@@ -45,13 +59,11 @@ import com.paw.key.presentation.ui.signup.viewmodel.SignUpViewModel
 @Composable
 private fun PreviewSignUpDogScreen() {
     PawKeyTheme {
-        SignUpDogScreen(
-            step = 0.75F,
-            navigateNext = {},
-        )
+
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
 @Composable
 fun SignUpDogRoute(
     navigateNext: () -> Unit,
@@ -74,29 +86,115 @@ private fun isAgeValid(ageKnown: SignUpContract.AgeKnown, dogAge: String): Boole
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 fun SignUpDogScreen(
     step: Float,
     navigateNext: () -> Unit,
     modifier: Modifier = Modifier,
+    progress: Float = 1F,
     viewModel: SignUpViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
+    val animatedProgress by animateFloatAsState(
+        targetValue = progress,
+        animationSpec = tween(
+            durationMillis = 1000,
+            easing = FastOutSlowInEasing
+        ),
+        label = "progress_animation"
+    )
+
+    val imagePermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+    val pickSingleMediaLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri != null) {
+            viewModel.onDogImageSelected(uri)
+        }
+    }
+
+    val galleryLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        if (uri != null) {
+            viewModel.onDogImageSelected(uri)
+        }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            galleryLauncher.launch("image/*")
+        }
+    }
+
+    val onClickImage = {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            pickSingleMediaLauncher.launch(
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+            )
+        } else {
+            permissionLauncher.launch(imagePermission)
+        }
+    }
 
     Box(modifier = modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize()) {
-            SignUpHeader(
-                title = stringResource(R.string.ic_onboarding_signup),
-                subtitle = stringResource(id = R.string.ic_onboarding_signup_subtitle_step3),
-                progress = step,
-            )
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = stringResource(id = R.string.ic_onboarding_signup),
+                    color = PawKeyTheme.colors.black,
+                    style = PawKeyTheme.typography.body16Sb,
+                    modifier = Modifier
+                        .padding(top = 16.dp),
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                LinearProgressIndicator(
+                    progress = { animatedProgress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp),
+                    color = PawKeyTheme.colors.green500,
+                    trackColor = PawKeyTheme.colors.gray100,
+                    strokeCap = StrokeCap.Square,
+                    gapSize = 0.dp,
+                    drawStopIndicator = {}
+                )
+            }
 
             LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(32.dp),
                 contentPadding = PaddingValues(16.dp),
                 modifier = Modifier.fillMaxSize()
             ) {
-                item { DogProfileImage() }
+                item{
+                    Text(
+                        text = stringResource(id = R.string.ic_onboarding_signup_subtitle_step3),
+                        color = PawKeyTheme.colors.black,
+                        style = PawKeyTheme.typography.head22Sb,
+                        modifier = Modifier
+                            .padding(top = 20.dp)
+                    )
+                }
+                item {
+                    DogProfileImage(
+                        dogImage = state.dogImage,
+                        onClickImage = onClickImage
+                    )
+                }
 
                 item {
                     DogNameField(
@@ -152,15 +250,17 @@ fun SignUpDogScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .padding(16.dp)
+                .padding(horizontal = 16.dp, vertical = 46.dp)
         )
 
-        Spacer(modifier = Modifier.height(34.dp))
     }
 }
 
 @Composable
-private fun DogProfileImage() {
+private fun DogProfileImage(
+    dogImage: Uri?,
+    onClickImage: () -> Unit
+) {
     Column {
         Box(
             contentAlignment = Alignment.Center,
@@ -173,14 +273,30 @@ private fun DogProfileImage() {
                 modifier = Modifier
                     .size(96.dp)
                     .clip(CircleShape)
-                    .border(1.dp, PawKeyTheme.colors.white2, CircleShape)
+                    .border(
+                        width = 2.dp,
+                        color = if (dogImage != null) PawKeyTheme.colors.green500 else PawKeyTheme.colors.white2,
+                        shape = CircleShape
+                    )
                     .background(PawKeyTheme.colors.white2)
+                    .noRippleClickable { onClickImage() }
             ) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_onboarding_img_plus),
-                    contentDescription = "앨범",
-                    tint = PawKeyTheme.colors.gray100
-                )
+                if (dogImage != null) {
+                    AsyncImage(
+                        model = dogImage,
+                        contentDescription = "강아지 프로필 이미지",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .size(92.dp)
+                            .clip(CircleShape)
+                    )
+                } else {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_onboarding_img_plus),
+                        contentDescription = "앨범",
+                        tint = PawKeyTheme.colors.gray100
+                    )
+                }
             }
         }
     }
@@ -256,9 +372,8 @@ private fun NeuteringCheckbox(
             color = if (isNeutered)
                 PawKeyTheme.colors.black
             else PawKeyTheme.colors.gray300,
-            style = if (isNeutered)
-                PawKeyTheme.typography.body14Sb
-            else PawKeyTheme.typography.body14R
+            style = PawKeyTheme.typography.body14Sb
+
         )
     }
 }

--- a/app/src/main/java/com/paw/key/presentation/ui/signup/SignUpLevelScreen.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/signup/SignUpLevelScreen.kt
@@ -95,8 +95,8 @@ fun SignUpLevelScreen(
             LevelSection(
                 title = stringResource(id = R.string.ic_onboarding_signup_social_level),
                 options = listOf(
-                    listOf("잘 안 친해요", "친해려 친해해요"),
-                    listOf("잘 친해해요", "친구왕이에요")
+                    listOf("잘 어울려요", "천천히 친해져요"),
+                    listOf("낯을 가려요", "상관없어요")
                 ),
                 selectedOption = selectedSocialLevel,
                 onOptionClick = { option ->

--- a/app/src/main/java/com/paw/key/presentation/ui/signup/state/SignUpContract.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/signup/state/SignUpContract.kt
@@ -1,5 +1,6 @@
 package com.paw.key.presentation.ui.signup.state
 
+import android.net.Uri
 import androidx.compose.runtime.Immutable
 
 class SignUpContract {
@@ -10,6 +11,7 @@ class SignUpContract {
         val isLocationMenuVisible: Boolean = false,
         val name: String = "",
         val age: String = "",
+        val dogImage: Uri? = null,
 
         val dogName: String = "",
         val dogGender: DogGender = DogGender.UNKNOWN,

--- a/app/src/main/java/com/paw/key/presentation/ui/signup/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/com/paw/key/presentation/ui/signup/viewmodel/SignUpViewModel.kt
@@ -1,5 +1,6 @@
 package com.paw.key.presentation.ui.signup.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import com.paw.key.presentation.ui.signup.state.SignUpContract
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -7,6 +8,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
@@ -25,6 +27,10 @@ class SignUpViewModel @Inject constructor(
         _state.value = _state.value.copy(
             selectedGender = gender
         )
+    }
+
+    fun onDogImageSelected(uri: Uri) {
+        _state.update { it.copy(dogImage = uri) }
     }
 
     fun selectDistrict(districts: List<String>) {

--- a/app/src/main/res/drawable/ic_eye_linear_gray_invalid.xml
+++ b/app/src/main/res/drawable/ic_eye_linear_gray_invalid.xml
@@ -1,0 +1,48 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14.53,9.472L9.47,14.532C8.82,13.882 8.42,12.992 8.42,12.002C8.42,10.022 10.02,8.422 12,8.422C12.99,8.422 13.88,8.822 14.53,9.472Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M17.82,5.77C16.07,4.45 14.07,3.73 12,3.73C8.47,3.73 5.18,5.81 2.89,9.41C1.99,10.821 1.99,13.191 2.89,14.601C3.68,15.84 4.6,16.91 5.6,17.771"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8.42,19.53C9.56,20.01 10.77,20.27 12,20.27C15.53,20.27 18.82,18.19 21.11,14.59C22.01,13.18 22.01,10.81 21.11,9.4C20.78,8.88 20.42,8.39 20.05,7.93"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M15.51,12.699C15.25,14.109 14.1,15.259 12.69,15.519"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M9.47,14.531L2,22.001"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M22,2L14.53,9.47"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_eye_linear_gray_valid.xml
+++ b/app/src/main/res/drawable/ic_eye_linear_gray_valid.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15.58,12.002C15.58,13.982 13.98,15.582 12,15.582C10.02,15.582 8.42,13.982 8.42,12.002C8.42,10.022 10.02,8.422 12,8.422C13.98,8.422 15.58,10.022 15.58,12.002Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M12,20.269C15.53,20.269 18.82,18.189 21.11,14.589C22.01,13.179 22.01,10.809 21.11,9.399C18.82,5.799 15.53,3.719 12,3.719C8.47,3.719 5.18,5.799 2.89,9.399C1.99,10.809 1.99,13.179 2.89,14.589C5.18,18.189 8.47,20.269 12,20.269Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#BDBDBD"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,8 +34,8 @@
     <string name="ic_onboarding_signup_dog_name">반려견 이름</string>
     <string name="ic_onboarding_signup_dog_breed">견종</string>
 
-    <string name="ic_onboarding_signup_energy_level">활동성</string>
-    <string name="ic_onboarding_signup_social_level">친밀도</string>
+    <string name="ic_onboarding_signup_energy_level">에너지 레벨</string>
+    <string name="ic_onboarding_signup_social_level">사회성 레벨</string>
 
     <!-- Navigation -->
     <!--Home-->


### PR DESCRIPTION
---
name: pull_request_template
about: pr 생성용 템플릿입니다~
title: ''
labels: ''
assignees: ''

---

## ISSUE
- closed #68 

## ❗ WORK DESCRIPTIONAdd commentMore actions
- OnboardingScreen : 하단 버튼 border, padding 수정
- LoginScreen : 하단 버튼 border, padding 수정, 메인 타이틀 color 수정
- SignUpScreenDog : photopicker, 커미션 추가, button enabled + padding 수정,
- HomeScreen : Calendar card 요소 color, 위치 수정, 날씨 아이콘 수정 
- SignUpLevelScreen : 버튼 텍스트 요소 변경
## 📸 SCREENSHOT
<img src="" width="300" />
<img width="485" height="547" alt="image" src="https://github.com/user-attachments/assets/0e752390-a371-4257-9bbc-abfa8b9a5d2d" />
<img width="300" height="1079" alt="image" src="https://github.com/user-attachments/assets/23318e9c-bf86-400f-a9c7-eec12169784f" />
<img width="300" height="1200" alt="image" src="https://github.com/user-attachments/assets/378168f7-4361-48d2-a242-4e9b4dbb111f" />
<img width="300" height="1200" alt="image" src="https://github.com/user-attachments/assets/40dae69f-1e5b-4993-9667-b6e22dbca96e" />
<img width="300" height="1200" alt="image" src="https://github.com/user-attachments/assets/60e39aef-f02c-4af1-8a29-736c6d4584a9" />
<img width="300" height="1200" alt="image" src="https://github.com/user-attachments/assets/49a67863-be03-4719-a8fd-c8e7c5cfcccd" />
<img width="300" height="1200" alt="image" src="https://github.com/user-attachments/assets/e227c3d8-4b84-4ece-aba7-de51ae5b5852" />




BEFORE | AFTER
-- | --
 | 

## 📢 TO REVIEWERS
- 포토피커에서 사진 선택하는게 에뮬에서 안돼서, 디바이스에서 확인부탁드립니다.
- bottomsheet 에서 하단 버튼 enable되는거 api 연결하면서 한번에 수정하는게 나을것같아서 이후에 수정하겠습니다
